### PR TITLE
feat: add array mapping support

### DIFF
--- a/compiler-plugin/src/main/kotlin/tech/mappie/ir/analysis/problems/classes/UnsafeTypeAssignmentProblems.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/ir/analysis/problems/classes/UnsafeTypeAssignmentProblems.kt
@@ -11,6 +11,7 @@ import tech.mappie.ir.util.location
 import tech.mappie.ir.analysis.Problem
 import tech.mappie.ir.analysis.ValidationContext
 import tech.mappie.ir.reporting.pretty
+import tech.mappie.ir.util.isArray
 import tech.mappie.ir.util.isList
 import tech.mappie.ir.util.isSet
 
@@ -80,6 +81,8 @@ class UnsafeTypeAssignmentProblems(
                 || ((source.type.isNullable() && !source.type.hasFlexibleNullabilityAnnotation()) && !target.type.isNullable())
 
         private fun isCompatibleCollection(source: ClassMappingSource, target: ClassMappingTarget): Boolean =
-            source.type.isList() && target.type.isList() || source.type.isSet() && target.type.isSet()
+            source.type.isList() && target.type.isList() ||
+            source.type.isSet() && target.type.isSet() ||
+            source.type.isArray() && target.type.isArray()
     }
 }

--- a/compiler-plugin/src/main/kotlin/tech/mappie/ir/generation/TransformationConstructor.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/ir/generation/TransformationConstructor.kt
@@ -41,6 +41,8 @@ private fun PropertyMappingViaMapperTransformation.selectTransformationFunction(
         value.type.isList() -> mapper.referenceMapListFunction()
         value.type.isSet() && value.type.isNullable() -> mapper.referenceMapNullableSetFunction()
         value.type.isSet() -> mapper.referenceMapSetFunction()
+        value.type.isArray() && value.type.isNullable() -> mapper.referenceMapNullableArrayFunction()
+        value.type.isArray() -> mapper.referenceMapArrayFunction()
         value.type.isNullable() -> mapper.referenceMapNullableFunction()
         else -> mapper.referenceMapFunction()
     }
@@ -55,6 +57,10 @@ private fun IrClass.selectTransformationFunction(value: IrExpression) =
             listOf(this, superClass!!).firstNotNullOf { it.functions.firstOrNull { it.isMappieMapNullableSetFunction() } }
         value.type.isSet() ->
             listOf(this, superClass!!).firstNotNullOf { it.functions.firstOrNull { it.isMappieMapSetFunction() } }
+        value.type.isArray() && value.type.isNullable() ->
+            listOf(this, superClass!!).firstNotNullOf { it.functions.firstOrNull { it.isMappieMapNullableArrayFunction() } }
+        value.type.isArray() ->
+            listOf(this, superClass!!).firstNotNullOf { it.functions.firstOrNull { it.isMappieMapArrayFunction() } }
         value.type.isNullable() ->
             listOf(this, superClass!!).firstNotNullOf { it.functions.firstOrNull { it.isMappieMapNullableFunction() } }
         else -> functions.first { it.isMappieMapFunction() }

--- a/compiler-plugin/src/main/kotlin/tech/mappie/ir/resolving/MappieDefinitions.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/ir/resolving/MappieDefinitions.kt
@@ -14,6 +14,8 @@ data class MappieDefinition(
     fun referenceMapListFunction() = clazz.functions.first { it.isMappieMapListFunction() }
     fun referenceMapNullableSetFunction() = clazz.functions.first { it.isMappieMapNullableSetFunction() }
     fun referenceMapSetFunction() = clazz.functions.first { it.isMappieMapSetFunction() }
+    fun referenceMapNullableArrayFunction() = clazz.functions.first { it.isMappieMapNullableArrayFunction() }
+    fun referenceMapArrayFunction() = clazz.functions.first { it.isMappieMapArrayFunction() }
     fun referenceMapNullableFunction() = clazz.functions.first { it.isMappieMapNullableFunction() }
     fun referenceMapFunction() = clazz.functions.first { it.isMappieMapFunction() }
 }
@@ -21,12 +23,12 @@ data class MappieDefinition(
 fun List<MappieDefinition>.matching(source: IrType, target: IrType) =
     filter {
         when {
-            (source.isList() && target.isList()) || (source.isSet() && target.isSet()) -> {
+            (source.isList() && target.isList()) || (source.isSet() && target.isSet()) || (source.isArray() && target.isArray()) -> {
                 val source = (source as IrSimpleType).arguments.first().typeOrFail
                 val target = (target as IrSimpleType).arguments.first().typeOrFail
                 it.source.isMappableFrom(source) && target.isMappableFrom(it.target.makeNullable())
             }
-            (source.isList() xor target.isList()) || (source.isSet() xor target.isSet()) -> {
+            (source.isList() xor target.isList()) || (source.isSet() xor target.isSet()) || (source.isArray() xor target.isArray()) -> {
                 false
             }
             else -> {

--- a/compiler-plugin/src/main/kotlin/tech/mappie/ir/resolving/classes/ExplicitClassMappingCollector.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/ir/resolving/classes/ExplicitClassMappingCollector.kt
@@ -109,13 +109,13 @@ private class MapperReferenceCollector(private val context: ResolverContext)
         require(expression.origin == IrStatementOrigin.GET_PROPERTY)
 
         return when (val name = expression.symbol.owner.name) {
-            getterName("forList"), getterName("forSet") -> {
+            getterName("forList"), getterName("forSet"), getterName("forArray") -> {
                 val mapper = expression.symbol.owner.parent as IrClass
                 PropertyMappingViaMapperTransformation(MappieDefinition(mapper), expression.dispatchReceiver!!)
             }
             else -> {
                 context.fail(
-                    "Unexpected call of ${name.asString()}, expected forList or forSet",
+                    "Unexpected call of ${name.asString()}, expected forList, forSet or forArray",
                     expression,
                     location(context.origin.fileEntry, expression)
                 )

--- a/compiler-plugin/src/main/kotlin/tech/mappie/ir/resolving/classes/sources/TransformableClassMappingSource.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/ir/resolving/classes/sources/TransformableClassMappingSource.kt
@@ -13,6 +13,7 @@ import tech.mappie.ir.resolving.MappieDefinition
 import tech.mappie.ir.resolving.classes.targets.ClassMappingTarget
 import tech.mappie.ir.util.isList
 import tech.mappie.ir.util.isSet
+import tech.mappie.ir.util.isArray
 import tech.mappie.ir.util.mappieType
 
 sealed interface TransformableClassMappingSource : ClassMappingSource {
@@ -30,6 +31,7 @@ sealed interface TransformableClassMappingSource : ClassMappingSource {
                     when {
                         original.isSet() -> context.irBuiltIns.setClass.typeWith(transformation.type)
                         original.isList() -> context.irBuiltIns.listClass.typeWith(transformation.type)
+                        original.isArray() -> context.irBuiltIns.arrayClass.typeWith(transformation.type)
                         else -> transformation.type
                     }.run { if (original.isNullable()) makeNullable() else this }.addAnnotations(original.annotations)
                 }

--- a/compiler-plugin/src/main/kotlin/tech/mappie/ir/util/Ir.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/ir/util/Ir.kt
@@ -56,6 +56,16 @@ fun IrSimpleFunction.isMappieMapSetFunction() =
         && parameters.singleOrNull { it.kind == IrParameterKind.Regular }?.type?.isSet() == true
         && returnType.isSet()
 
+fun IrSimpleFunction.isMappieMapNullableArrayFunction() =
+    name == IDENTIFIER_MAP_NULLABLE_ARRAY
+        && parameters.singleOrNull { it.kind == IrParameterKind.Regular }?.type?.isArray() == true
+        && returnType.isArray()
+
+fun IrSimpleFunction.isMappieMapArrayFunction() =
+    name == IDENTIFIER_MAP_ARRAY
+        && parameters.singleOrNull { it.kind == IrParameterKind.Regular }?.type?.isArray() == true
+        && returnType.isArray()
+
 fun IrSimpleFunction.isMappieMapNullableFunction() =
     name == IDENTIFIER_MAP_NULLABLE
         && parameters.singleOrNull { it.kind == IrParameterKind.Regular }?.type?.isNullable() == true

--- a/compiler-plugin/src/main/kotlin/tech/mappie/ir/util/TypeUtils.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/ir/util/TypeUtils.kt
@@ -11,16 +11,16 @@ import tech.mappie.exceptions.MappiePanicException.Companion.panic
 import tech.mappie.ir.MappieIrRegistrar.Companion.context
 
 fun IrType.isMappableFrom(other: IrType): Boolean = when {
-    (isList() && other.isList()) || (isSet() && other.isSet()) ->
+    (isList() && other.isList()) || (isSet() && other.isSet()) || (isArray() && other.isArray()) ->
         (this as IrSimpleType).arguments.first().typeOrFail.isMappableFrom((other as IrSimpleType).arguments.first().typeOrFail)
-    (isList() xor other.isList()) || (isSet() xor other.isSet()) ->
+    (isList() xor other.isList()) || (isSet() xor other.isSet()) || (isArray() xor other.isArray()) ->
         false
     else ->
         isSubtypeOf(other, IrTypeSystemContextImpl(context.irBuiltIns))
 }
 
 fun IrType.mappieType() = when {
-    isList() || isSet() -> (this as IrSimpleType).arguments.first().typeOrFail
+    isList() || isSet() || isArray() -> (this as IrSimpleType).arguments.first().typeOrFail
     isNullable() -> this.makeNotNull()
     else -> this
 }
@@ -36,6 +36,9 @@ fun IrType.isSet() =
         "kotlin.collections.Set",
         "kotlin.collections.MutableSet",
     )
+
+fun IrType.isArray() =
+    classOrNull?.owner?.fqNameWhenAvailable?.asString() == "kotlin.Array"
 
 fun IrType.hasFlexibleNullabilityAnnotation(): Boolean =
     annotations.any { it.symbol.owner.parentAsClass.classId == FlexibleNullability }

--- a/compiler-plugin/src/main/kotlin/tech/mappie/util/Identifiers.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/util/Identifiers.kt
@@ -18,6 +18,10 @@ val IDENTIFIER_MAP_NULLABLE_SET = Name.identifier("mapNullableSet")
 
 val IDENTIFIER_MAP_SET = Name.identifier("mapSet")
 
+val IDENTIFIER_MAP_NULLABLE_ARRAY = Name.identifier("mapNullableArray")
+
+val IDENTIFIER_MAP_ARRAY = Name.identifier("mapArray")
+
 val IDENTIFIER_FROM_ENUM_ENTRY = Name.identifier("fromEnumEntry")
 
 val IDENTIFIER_THROWN_BY_ENUM_ENTRY = Name.identifier("thrownByEnumEntry")

--- a/compiler-plugin/src/test/kotlin/tech/mappie/testing/arrays/ArrayPropertyObjectToArrayPropertyPrimitiveTest.kt
+++ b/compiler-plugin/src/test/kotlin/tech/mappie/testing/arrays/ArrayPropertyObjectToArrayPropertyPrimitiveTest.kt
@@ -1,0 +1,87 @@
+package tech.mappie.testing.arrays
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import tech.mappie.testing.compilation.compile
+import tech.mappie.testing.loadObjectMappieClass
+import java.io.File
+
+class ArrayPropertyObjectToArrayPropertyPrimitiveTest {
+    data class Input(val text: Array<InnerInput>)
+    data class InnerInput(val value: String)
+
+    data class Output(val text: Array<String>)
+
+    @TempDir
+    lateinit var directory: File
+
+    @Test
+    fun `map array explicit with implicit via should succeed`() {
+        compile(directory) {
+            file("Test.kt",
+                """
+                import tech.mappie.api.ObjectMappie
+                import tech.mappie.testing.arrays.ArrayPropertyObjectToArrayPropertyPrimitiveTest.*
+
+                class Mapper : ObjectMappie<Input, Output>() {
+                    override fun map(from: Input) = mapping {
+                        Output::text fromProperty from::text
+                    }
+                }
+
+                object InnerMapper : ObjectMappie<InnerInput, String>() {
+                    override fun map(from: InnerInput) = from.value
+                }
+                """
+            )
+        } satisfies {
+            isOk()
+            hasNoWarningsOrErrors()
+
+            val mapper = classLoader
+                .loadObjectMappieClass<Input, Output>("Mapper")
+                .constructors
+                .first()
+                .call()
+
+            assertThat(mapper.map(Input(arrayOf(InnerInput("A"), InnerInput("B")))))
+                .isEqualTo(Output(arrayOf("A", "B")))
+        }
+    }
+
+    @Test
+    fun `map via forArray should succeed`() {
+        compile(directory) {
+            file("Test.kt",
+                """
+                import tech.mappie.api.ObjectMappie
+                import tech.mappie.testing.arrays.ArrayPropertyObjectToArrayPropertyPrimitiveTest.*
+
+                class Mapper : ObjectMappie<Input, Output>() {
+                    override fun map(from: Input) = mapping {
+                        Output::text fromProperty from::text via InnerMapper.forArray
+                    }
+                }
+
+                object InnerMapper : ObjectMappie<InnerInput, String>() {
+                    override fun map(from: InnerInput) = from.value
+                }
+                """
+            )
+        } satisfies {
+            isOk()
+            hasNoWarningsOrErrors()
+
+            val mapper = classLoader
+                .loadObjectMappieClass<Input, Output>("Mapper")
+                .constructors
+                .first()
+                .call()
+
+            assertThat(mapper.map(Input(arrayOf(InnerInput("A"), InnerInput("B")))))
+                .isEqualTo(Output(arrayOf("A", "B")))
+        }
+    }
+}
+

--- a/compiler-plugin/src/test/kotlin/tech/mappie/testing/arrays/MapArrayTest.kt
+++ b/compiler-plugin/src/test/kotlin/tech/mappie/testing/arrays/MapArrayTest.kt
@@ -1,0 +1,47 @@
+package tech.mappie.testing.arrays
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import tech.mappie.testing.compilation.compile
+import tech.mappie.testing.loadObjectMappieClass
+import java.io.File
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class MapArrayTest {
+
+    data class Input(val value: LocalDateTime)
+
+    data class Output(val value: LocalDate)
+
+    @TempDir
+    lateinit var directory: File
+
+    @Test
+    fun `mapArray implicit succeed`() {
+        compile(directory) {
+            file("Test.kt",
+                """
+                import tech.mappie.api.ObjectMappie
+                import tech.mappie.testing.arrays.MapArrayTest.*
+
+                class Mapper : ObjectMappie<Input, Output>()
+                """
+            )
+        } satisfies {
+            isOk()
+            hasNoWarningsOrErrors()
+
+            val mapper = classLoader
+                .loadObjectMappieClass<Input, Output>("Mapper")
+                .constructors
+                .first()
+                .call()
+
+            assertThat(mapper.mapArray(arrayOf(Input(LocalDateTime.MIN), Input(LocalDateTime.MAX))))
+                .isEqualTo(arrayOf(Output(LocalDate.MIN), Output(LocalDate.MAX)))
+        }
+    }
+}
+

--- a/mappie-api/src/commonMain/kotlin/tech/mappie/api/ArrayMappie.kt
+++ b/mappie-api/src/commonMain/kotlin/tech/mappie/api/ArrayMappie.kt
@@ -1,0 +1,7 @@
+package tech.mappie.api
+
+/**
+ * Base mapper class for array mappers. Cannot be instantiated, but can be created by using the field [ObjectMappie.forArray].
+ */
+public sealed class ArrayMappie<out TO> : Mappie<Array<TO>>
+

--- a/mappie-api/src/commonMain/kotlin/tech/mappie/api/EnumMappie.kt
+++ b/mappie-api/src/commonMain/kotlin/tech/mappie/api/EnumMappie.kt
@@ -55,6 +55,15 @@ public abstract class EnumMappie<FROM: Enum<*>, TO> : Mappie<TO> {
         HashSet<TO>(from.size).apply { from.forEach { add(map(it)) } }
 
     /**
+     * Map each element in [from] to an instance of [TO].
+     *
+     * @param from the source values.
+     * @return [from] mapped to an array of instances of [TO].
+     */
+    public open fun mapArray(from: Array<FROM>): Array<TO> =
+        Array(from.size) { index -> map(from[index]) }
+
+    /**
      * Mapping function which instructs Mappie to generate code for this implementation.
      *
      * @param builder the configuration for the generation of this mapping.

--- a/mappie-api/src/commonMain/kotlin/tech/mappie/api/ObjectMappie.kt
+++ b/mappie-api/src/commonMain/kotlin/tech/mappie/api/ObjectMappie.kt
@@ -32,6 +32,12 @@ public abstract class ObjectMappie<FROM, out TO> : Mappie<TO> {
         error("The mapper forSet should only be used in the context of 'via'. Use mapSet instead.")
 
     /**
+     * A mapper for [Array] to be used in [TransformableValue.via].
+     */
+    public val forArray: ArrayMappie<TO> get() =
+        error("The mapper forArray should only be used in the context of 'via'. Use mapArray instead.")
+
+    /**
      * Map [from] to an instance of [TO].
      *
      * @param from the source value.
@@ -83,6 +89,24 @@ public abstract class ObjectMappie<FROM, out TO> : Mappie<TO> {
      */
     public open fun mapNullableSet(from: Set<FROM>?): Set<TO>? =
         from?.let { HashSet<TO>(it.size).apply { from.forEach { add(map(it)) } } }
+
+    /**
+     * Map each element in [from] to an instance of [TO].
+     *
+     * @param from the source values.
+     * @return [from] mapped to an array of instances of [TO].
+     */
+    public open fun mapArray(from: Array<FROM>): Array<TO> =
+        Array(from.size) { index -> map(from[index]) }
+
+    /**
+     * Map each element in [from] to an instance of [TO] if [from] is not null.
+     *
+     * @param from the source values.
+     * @return [from] mapped to an array of instances of [TO].
+     */
+    public open fun mapNullableArray(from: Array<FROM>?): Array<TO>? =
+        from?.let { Array(it.size) { index -> map(it[index]) } }
 
     /**
      * Mapping function which instructs Mappie to generate code for this implementation.


### PR DESCRIPTION
## Summary
- add `forArray`, `mapArray`, and `mapNullableArray` to ObjectMappie
- introduce `ArrayMappie` base class and array helpers across the compiler plugin
- support array mapping in EnumMappie and add array mapping tests

## Testing
- `./gradlew test` *(fails: Unable to download toolchain matching the requirements)*
- `./gradlew -Porg.gradle.java.installations.auto-download=false test` *(fails: Plugin [id: 'org.gradle.kotlin.kotlin-dsl', version: '6.2.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae821c1cf48333b9470725749bae44