### PR TITLE
ci: build all branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - 'main'
+      - '**'
     paths:
       - '**'
       - '!website/**'


### PR DESCRIPTION
## Summary
- run CI build workflow for all branches

## Testing
- `./gradlew build` *(fails: Plugin [id: 'org.gradle.kotlin.kotlin-dsl', version: '6.2.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8be0cb3c8333a4b2228f14a87c33